### PR TITLE
chore: update links in header to fix them opening explorer window

### DIFF
--- a/src/modpack.json
+++ b/src/modpack.json
@@ -2,7 +2,7 @@
   "name": "Wildlander",
   "logo": "images/logos/wildlander-full-light.svg",
   "backgroundImage": "images/background.png",
-  "website": "www.wildlandermod.com",
-  "wiki": "www.wildlander.com",
+  "website": "https://www.wildlandermod.com",
+  "wiki": "https://docs.google.com/document/d/1SXZSma38Mw2lTpDOY-pZRTYmpIUb6y0UYL4X7cZg2Ps",
   "patreon": "https://www.patreon.com/dylanbperry"
 }


### PR DESCRIPTION
The previous links simply opened an explorer window instead of the link itself. Added https:// for the website link, and linked the wiki to the temporary wiki for now.

closes #357 