### PR TITLE
chore: remove close skyrim button

### DIFF
--- a/src/components/TheNavigation.vue
+++ b/src/components/TheNavigation.vue
@@ -65,12 +65,9 @@
   <AppModal :show-modal="gameRunning" name="gameRunning">
     <div class="l-column l-center">
       <div class="u-spacing">
-        Skyrim is currently launching/running. To use the launcher, please close
-        Skyrim first.
+        Skyrim is currently launching/running, please wait. This is not an
+        error, and the launching process may take several minutes.
       </div>
-      <BaseButton type="primary" size="large" @click="closeGame"
-        >Close Skyrim
-      </BaseButton>
     </div>
   </AppModal>
 </template>


### PR DESCRIPTION
It's been causing some issues, so for now, simply yeet the button for now.

This is a temporary fix to immediate deal with some of the issues it's causing, while we work on a more fancy fix in Taran's PR/Branch