### PR TITLE
feat: add api caching

### DIFF
--- a/src/renderer/services/cache.service.ts
+++ b/src/renderer/services/cache.service.ts
@@ -7,10 +7,6 @@ import { logger } from "@/main/logger";
 export class CacheService {
   /**
    * Returns data from the localStorage if it exists and is newer than maxAge
-   * @param key the key to take the data from
-   * @param maxAge the max age in seconds the data can have (storeDateTime - now > maxAge*1000)
-   *
-   * @returns T|undefined data of type T if found and new enough, otherwise undefined
    */
   public get<T>(key: string, maxAge: number): T | undefined {
     maxAge *= 1000; // convert s to ms for comparison
@@ -30,8 +26,6 @@ export class CacheService {
 
   /**
    * Sets data in the localStorage, overwrites regardless of previous data presence
-   * @param key to store the data in
-   * @param data to store
    */
   public set(key: string, data: unknown) {
     logger.debug(`Cache: setting data for "${key}".`);

--- a/src/renderer/services/cache.service.ts
+++ b/src/renderer/services/cache.service.ts
@@ -1,0 +1,46 @@
+import { logger } from "@/main/logger";
+
+/**
+ * The CacheService class is a simple wrapper around window.localStorage
+ * localStorage can only store strings so this wrapper JSON.stringifies all data
+ */
+export class CacheService {
+  /**
+   * Returns data from the localStorage if it exists and is newer than maxAge
+   * @param key the key to take the data from
+   * @param maxAge the max age in seconds the data can have (storeDateTime - now > maxAge*1000)
+   *
+   * @returns T|undefined data of type T if found and new enough, otherwise undefined
+   */
+  public get<T>(key: string, maxAge: number): T | undefined {
+    maxAge *= 1000; // convert s to ms for comparison
+    const now = new Date();
+    logger.debug(`Cache: query "${key}" with maxAge: ${maxAge}.`);
+    const rawData = window.localStorage.getItem(key);
+    if (rawData !== null) {
+      const data: { age: number; content: T } = JSON.parse(rawData);
+      if (now.getTime() - data.age < maxAge) {
+        logger.debug(`Cache: returning data for "${key}"`);
+        return data.content;
+      }
+    }
+    logger.debug(`Cache: could not find "${key}" in cache or too old`);
+    return undefined;
+  }
+
+  /**
+   * Sets data in the localStorage, overwrites regardless of previous data presence
+   * @param key to store the data in
+   * @param data to store
+   */
+  public set(key: string, data: unknown) {
+    logger.debug(`Cache: setting data for "${key}".`);
+    window.localStorage.setItem(
+      key,
+      JSON.stringify({
+        age: new Date().getTime(),
+        content: data,
+      })
+    );
+  }
+}

--- a/src/renderer/services/patreon.service.ts
+++ b/src/renderer/services/patreon.service.ts
@@ -1,5 +1,16 @@
+import { CacheService } from "@/renderer/services/cache.service";
+
 export class PatreonService {
   private patrons: Patron[] = [];
+  private readonly cacheKey = "patreon.patrons";
+  private cacheService = new CacheService();
+
+  constructor() {
+    const data = this.cacheService.get<Patron[]>(this.cacheKey, 60 * 60 * 24);
+    if (data !== undefined) {
+      this.patrons = data;
+    }
+  }
 
   /**
    * Taken from https://stackoverflow.com/a/12646864/3379536
@@ -24,6 +35,7 @@ export class PatreonService {
       this.patrons = shuffle
         ? PatreonService.shuffleArray(data.patrons)
         : data.patrons;
+      this.cacheService.set(this.cacheKey, this.patrons);
       return this.patrons;
     } catch (error) {
       throw new Error(`Failed to get Patrons: ${error}`);

--- a/src/renderer/services/patreon.service.ts
+++ b/src/renderer/services/patreon.service.ts
@@ -3,13 +3,10 @@ import { CacheService } from "@/renderer/services/cache.service";
 export class PatreonService {
   private patrons: Patron[] = [];
   private readonly cacheKey = "patreon.patrons";
-  private cacheService = new CacheService();
+  private readonly cacheService: CacheService;
 
-  constructor() {
-    const data = this.cacheService.get<Patron[]>(this.cacheKey, 60 * 60 * 24);
-    if (data !== undefined) {
-      this.patrons = data;
-    }
+  constructor(cacheService: CacheService) {
+    this.cacheService = cacheService;
   }
 
   /**
@@ -24,6 +21,13 @@ export class PatreonService {
   }
 
   public async getPatrons(shuffle = true): Promise<Patron[]> {
+    if (this.patrons.length === 0) {
+      const data = this.cacheService.get<Patron[]>(this.cacheKey, 60 * 60 * 24);
+      if (data !== undefined) {
+        this.patrons = data;
+      }
+    }
+
     try {
       if (this.patrons.length > 0) {
         return this.patrons;

--- a/src/renderer/services/posts.service.ts
+++ b/src/renderer/services/posts.service.ts
@@ -1,5 +1,16 @@
+import { CacheService } from "@/renderer/services/cache.service";
+
 export class PostsService {
   private news: Posts[] = [];
+  private readonly cacheKey = "patreon.posts";
+  private cacheService = new CacheService();
+
+  constructor() {
+    const data = this.cacheService.get<Posts[]>(this.cacheKey, 60 * 60 * 24);
+    if (data !== undefined) {
+      this.news = data;
+    }
+  }
 
   public async getPosts() {
     try {
@@ -9,6 +20,7 @@ export class PostsService {
 
       const response = await fetch("https://ultsky.phinocio.com/api/patreon");
       this.news = (await response.json()).posts as Posts[];
+      this.cacheService.set(this.cacheKey, this.news);
       return this.news;
     } catch (error) {
       throw new Error(`Failed to get News: ${error}`);

--- a/src/renderer/services/posts.service.ts
+++ b/src/renderer/services/posts.service.ts
@@ -3,16 +3,20 @@ import { CacheService } from "@/renderer/services/cache.service";
 export class PostsService {
   private news: Posts[] = [];
   private readonly cacheKey = "patreon.posts";
-  private cacheService = new CacheService();
+  private readonly cacheService: CacheService;
 
-  constructor() {
-    const data = this.cacheService.get<Posts[]>(this.cacheKey, 60 * 60 * 24);
-    if (data !== undefined) {
-      this.news = data;
-    }
+  constructor(cacheService: CacheService) {
+    this.cacheService = cacheService;
   }
 
   public async getPosts() {
+    if (this.news.length === 0) {
+      const data = this.cacheService.get<Posts[]>(this.cacheKey, 60 * 60 * 24);
+      if (data !== undefined) {
+        this.news = data;
+      }
+    }
+
     try {
       if (this.news.length > 0) {
         return this.news;

--- a/src/renderer/services/service-container.ts
+++ b/src/renderer/services/service-container.ts
@@ -8,6 +8,7 @@ import { EventService } from "@/renderer/services/event.service";
 import { IpcService } from "@/renderer/services/ipc.service";
 import { UpdateService } from "@/renderer/services/update.service";
 import { ModpackService } from "@/renderer/services/modpack.service";
+import { CacheService } from "@/renderer/services/cache.service";
 
 export type EventService = Emitter<Record<EventType, unknown>>;
 
@@ -43,10 +44,14 @@ export function registerServices(app: App) {
   const ipcService = new IpcService();
   const updateService = new UpdateService();
   const modpackService = new ModpackService(ipcService);
+  const cacheService = new CacheService();
   app.provide(SERVICE_BINDINGS.UPDATE_SERVICE, updateService);
   app.provide(SERVICE_BINDINGS.IPC_SERVICE, ipcService);
-  app.provide(SERVICE_BINDINGS.PATRON_SERVICE, new PatreonService());
-  app.provide(SERVICE_BINDINGS.NEWS_SERVICE, new PostsService());
+  app.provide(
+    SERVICE_BINDINGS.PATRON_SERVICE,
+    new PatreonService(cacheService)
+  );
+  app.provide(SERVICE_BINDINGS.NEWS_SERVICE, new PostsService(cacheService));
   app.provide(SERVICE_BINDINGS.MESSAGE_SERVICE, new MessageService(ipcService));
   app.provide(SERVICE_BINDINGS.EVENT_SERVICE, EventService);
   app.provide(SERVICE_BINDINGS.MODAL_SERVICE, new ModalService(EventService));


### PR DESCRIPTION
closes #383 

I added a new helper directory since I didn't really see a good place to fit the CacheHelper class otherwise.
If you prefer it being in a different directory or perhaps converted to just export functions instead of a class, please open the discussions required or alternatively directly edit it yourself.


I tested this both via npm run serve and via a local build which I installed. It does seem to work as intended. To test locally  in regards to maxAge, clone it and set the maxAge to 60 or similar to do manual tests.

Initially the patreon.patrons key is twice, it seems this is due to the fact that both `TheFooter.vue` and `Patrons.vue` call `PatreonService.getPatrons`

This is my first pull request to this repo so I gladly welcome any feedback - be it regarding the code or the description here.