### PR TITLE
fix: fix migration for new users not working

### DIFF
--- a/src/main/services/migration.service.ts
+++ b/src/main/services/migration.service.ts
@@ -102,7 +102,7 @@ export class MigrationService {
         profiles.find((profile) => profile.toLowerCase().includes("potato")) ??
         profiles[[profiles].length - 1];
       await copy(profiles[0], standardProfilePath);
-      await copy(performanceProfile, standardProfilePath);
+      await copy(performanceProfile, performanceProfilePath);
     }
   }
 


### PR DESCRIPTION
The potato profile was overwriting the standard profile