### PR TITLE
fix: supress mouse4 and mouse5 browser navigation which could break the app

### DIFF
--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -15,3 +15,9 @@ app
   .use(VueFinalModal())
   .use(VueClickAway)
   .mount("#app");
+
+// Prevent Mouse 4 and Mouse 5 from navigating the app
+// Ref: https://stackoverflow.com/a/66318490 GitHub Issue 654
+window.addEventListener("mouseup", (e) => {
+  if (e.button === 3 || e.button === 4) e.preventDefault();
+});


### PR DESCRIPTION
The location of this snippet may be "controversial".
I chose it mainly because it's such a central adjustment and it doesn't really fit into any Vue file I feel.
Though I'm not opposed to changing the location. 

- I did test it manually and it does indeed prevent it the buttons from navigating.
- I didn't choose the "app-command" [alternative](https://stackoverflow.com/a/66318490) based on the fact that the [issue](https://github.com/electron/electron/issues/17134) within electron's repo is still open.



Closes #654 